### PR TITLE
Added optional param to autofs::mountfile...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,8 +23,9 @@
 #   Example:
 #     {
 #       'home' => {
-#         mountpoint => '/home',
-#         file_source => 'puppet:///modules/mymodule/auto.home'
+#         mountpoint  => '/home',
+#         file_source => 'puppet:///modules/mymodule/auto.home',
+#         file_mode   => '0644',
 #       }
 #     }
 #

--- a/manifests/mountfile.pp
+++ b/manifests/mountfile.pp
@@ -2,7 +2,7 @@
 #
 # Provide custom map file containing mounts
 #
-define autofs::mountfile ($mountpoint, $file_source) {
+define autofs::mountfile ($mountpoint, $file_source, $file_mode = $autofs::config_file_mode) {
 
   $safe_target_name = regsubst($title, '[/:\n\s\*\(\)]', '_', 'GM')
 
@@ -12,7 +12,7 @@ define autofs::mountfile ($mountpoint, $file_source) {
     ensure  => 'present',
     owner   => $autofs::config_file_owner,
     group   => $autofs::config_file_group,
-    mode    => $autofs::config_file_mode,
+    mode    => $file_mode,
     source  => $file_source,
     notify  => Service[$autofs::service_name],
     require => Package[$autofs::package_name],

--- a/spec/classes/class_spec.rb
+++ b/spec/classes/class_spec.rb
@@ -56,7 +56,8 @@ describe 'autofs' do
               'mount_files' => {
                 'home' => {
                 'mountpoint' => '/home',
-                'file_source' => 'puppet:///modules/homefolder/auto.home'
+                'file_source' => 'puppet:///modules/homefolder/auto.home',
+                'file_mode' => '0644',
                 }
               }
             }
@@ -64,7 +65,7 @@ describe 'autofs' do
 
           it { is_expected.to compile.with_all_deps }
           it { should contain_autofs__mountfile('home') }
-          it { should contain_file('/etc/auto.home') }
+          it { should contain_file('/etc/auto.home').with({ 'mode' => '0644' })}
         end
 
         context "automount folder in nested directory structure" do


### PR DESCRIPTION
(in case we want to define an executable auto.cifs file with bash script inside)

FYI: I expanded the spec test (for mountfile, file_mode) even though it's an optional param (was uncertain if you wanted spec test or not).

--
Torgeir