### PR TITLE
Correct sample usage of autofs::mount define

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,7 +62,11 @@ Example usage for automounting home folders:
 
 Using the autofs::mount directly:
 
-    autofs::mount('nfs.com:/export/home','/home','-hard,rw')
+    autofs::mount { 'home':
+      remote => 'nfs.com:/export/home',
+      mountpoint => '/home',
+      options => '-hard,rw'
+    }
 
 Supplying a custom automount file:
 


### PR DESCRIPTION
The example in the README suggests that puppet defined types can be called positionally like functions.   This is incorrect so rework the example to use correct syntax.